### PR TITLE
Few Python fixes

### DIFF
--- a/pyunxor/unxor.py
+++ b/pyunxor/unxor.py
@@ -32,7 +32,7 @@ Written by Thomas Chopitea (@tomchop_)
 
 # quick shannon-entropy calculation
 def H(data):
-  	h = 0
+	h = 0
 	entropy = 0
 	for x in range(256):
 		p_x = float(data.count(chr(x)))/float(len(data))

--- a/pyunxor/unxor.py
+++ b/pyunxor/unxor.py
@@ -301,7 +301,7 @@ if __name__ == '__main__':
 
 	if args.key:
 		if not re.match("^([a-fA-F0-9]{2,2})+$",args.key):
-			print "The key must be given in hex (e.g. FF00FF00)"
+			print("The key must be given in hex (e.g. FF00FF00)")
 			exit()
 		crypt = infile.read()
 		key = genkey(args.key,len(crypt))


### PR DESCRIPTION
Just noticed that there was a mix of spaces and tab on the very first line of the script, causing an error on my Python interpreter:

![image](https://user-images.githubusercontent.com/1886319/80085104-125e2f00-8558-11ea-9a20-719b862f3860.png)

And I also noticed that there was no parenthesis around the print argument, so the script can't work on Python 3.X interpreters even if it doesn't reach this part of the code.

![image](https://user-images.githubusercontent.com/1886319/80085540-a3cda100-8558-11ea-9f6e-34357ec999f0.png)

So after I edited the code to fix them, I just thought that it would be nice to fix them on the original repository as well, so new users won't have to fix these little bugs manually. ^^

Thank you for your tool by the way! =D